### PR TITLE
Fix group turn rotation and extend question validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Bu proje, ortaokul öğrencileri için hazırlanmış kapsamlı bir Sosyal Bilgi
 
 ## Öğretmen Paneli Özellikleri
 - **Tekil soru ekleme:** Çoktan seçmeli, boşluk doldurma ve eşleştirme soruları için ayrıntılı form alanları.
-- **Toplu soru içe aktarma:** JSON formatında soruları doğrulama, ön izleme ve ekleme.
+- **Toplu soru içe aktarma:** JSON formatında soruları doğrulama, önizleme ve ekleme.
 - **Soru yönetimi:** Var olan soruları filtreleme, düzenleme ve silme.
 - **İstatistikler:** Soru dağılımlarını ve toplam soru sayısını takip etme.
 

--- a/__tests__/teacherPanelModule.test.js
+++ b/__tests__/teacherPanelModule.test.js
@@ -101,4 +101,77 @@ describe('teacherPanelModule.validateQuestions', () => {
     expect(result.validQuestions).toHaveLength(1);
     expect(result.warnings).toContain('Soru 1: Benzer bir soru zaten mevcut.');
   });
+
+  test("rejects fill-in question without blank placeholder", () => {
+    const result = teacherPanelModule.validateQuestions([
+      {
+        grade: 6,
+        topic: 'Coğrafya',
+        difficulty: 'orta',
+        type: 'fill-in',
+        sentence: 'Türkiye haritasındaki boşluğu doğru kelimeyle tamamlayın.',
+        answer: 'Anadolu',
+        distractors: ['Karadeniz']
+      }
+    ]);
+
+    expect(result.errors).toContain("Soru 1: Cümle eksik veya '___' işareti yok.");
+    expect(result.validQuestions).toHaveLength(0);
+  });
+
+  test('rejects fill-in question without distractors', () => {
+    const result = teacherPanelModule.validateQuestions([
+      {
+        grade: 6,
+        topic: 'Coğrafya',
+        difficulty: 'orta',
+        type: 'fill-in',
+        sentence: "Türkiye'nin başkenti ___ şehridir.",
+        answer: 'Ankara',
+        distractors: []
+      }
+    ]);
+
+    expect(result.errors).toContain('Soru 1: En az 1 çeldirici gerekli.');
+    expect(result.validQuestions).toHaveLength(0);
+  });
+
+  test('rejects matching question with insufficient pairs', () => {
+    const result = teacherPanelModule.validateQuestions([
+      {
+        grade: 7,
+        topic: 'Tarih',
+        difficulty: 'zor',
+        type: 'matching',
+        question: 'Kişileri eserleriyle eşleştirin.',
+        pairs: [
+          { term: 'Yunus Emre', definition: 'İlahi şairi' },
+          { term: 'Karacaoğlan', definition: 'Halk ozanı' }
+        ]
+      }
+    ]);
+
+    expect(result.errors).toContain('Soru 1: En az 3 eşleştirme çifti gerekli.');
+    expect(result.validQuestions).toHaveLength(0);
+  });
+
+  test('rejects matching question when a pair is incomplete', () => {
+    const result = teacherPanelModule.validateQuestions([
+      {
+        grade: 7,
+        topic: 'Tarih',
+        difficulty: 'kolay',
+        type: 'matching',
+        question: 'Terimleri açıklamalarıyla eşleştirin.',
+        pairs: [
+          { term: 'Orhun Yazıtları', definition: 'Türk tarihinin ilk yazılı belgeleri' },
+          { term: 'Bilge Kağan', definition: '' },
+          { term: 'Tonyukuk', definition: 'Göktürk veziri' }
+        ]
+      }
+    ]);
+
+    expect(result.errors).toContain('Soru 1, Çift 2: Terim ve açıklama gerekli.');
+    expect(result.validQuestions).toHaveLength(0);
+  });
 });

--- a/soru.html
+++ b/soru.html
@@ -2081,6 +2081,7 @@
             
             state.answeredQuestions.add(state.currentQuestionIndex);
             this.updateProgressBar();
+            this.advanceTurnAfterQuestion();
         },
         
         checkFillInAnswer(selectedWord, question, draggedElement) {
@@ -2107,6 +2108,7 @@
 
                 state.answeredQuestions.add(state.currentQuestionIndex);
                 this.updateProgressBar();
+                this.advanceTurnAfterQuestion();
             } else {
                 // Yanlış: mesaj ve geri dönme etkisi
                 uiModule.playSound('incorrect');
@@ -2151,6 +2153,7 @@
                         state.answeredQuestions.add(state.currentQuestionIndex);
                         this.stopTimer();
                         this.updateProgressBar();
+                        this.advanceTurnAfterQuestion();
                     }
                 } else {
                     state.selectedMatchItem.classList.remove('selected');
@@ -2180,7 +2183,15 @@
             state.score[state.currentPlayer] += points;
             this.updateScoreBoard();
         },
-        
+
+        // Advance turn to next group after a question is completed
+        advanceTurnAfterQuestion() {
+            if (state.currentGameSettings.competitionMode !== 'grup') return;
+
+            state.currentPlayer = state.currentPlayer === 'grup1' ? 'grup2' : 'grup1';
+            this.updateScoreBoard();
+        },
+
         // Update score board
         updateScoreBoard() {
             const scoreBoard = document.getElementById('score-board');
@@ -2289,6 +2300,7 @@
                 }
 
                 uiModule.playSound('incorrect');
+                this.advanceTurnAfterQuestion();
             }
         },
         
@@ -2630,7 +2642,7 @@
         // Display filtered questions
         displayFilteredQuestions() {
             const container = document.getElementById('question-list-container');
-            // Arama filtresi aktifse filtrelenmiş soruları, değilse tüm soruları göster
+            // Herhangi bir filtre (arama, sınıf, zorluk veya tip) aktifse filtrelenmiş soruları, aksi halde tüm soruları göster
             const questionsToDisplay = (document.getElementById('question-search').value || document.getElementById('grade-filter').value || document.getElementById('difficulty-filter').value || document.getElementById('type-filter').value) 
                 ? state.filteredQuestions 
                 : allQuestions;


### PR DESCRIPTION
## Summary
- fix a typo in the README to use the correct "önizleme" form
- rotate the active group after each answered question so the scoreboard reflects the next team
- clarify the teacher panel filter comment and expand validation tests for fill-in and matching questions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cddd93f250832cbedcead6b9d46a85