### PR TITLE
Align developer credit block on the start screen

### DIFF
--- a/soru.html
+++ b/soru.html
@@ -174,13 +174,14 @@
         }
 
         .developer-section {
-            margin-top: 40px;
+            margin-top: auto;
+            align-self: flex-end;
             padding: 20px;
             background-color: var(--secondary-color);
             border-radius: var(--border-radius);
             box-shadow: var(--box-shadow);
             max-width: 500px;
-            text-align: left;
+            text-align: right;
         }
 
         .developer-section h3 {


### PR DESCRIPTION
## Summary
- update the start screen developer-section styling so the program developer credit sits in the bottom-right corner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce4fffeb60832c96d07207d8e36b64