### PR TITLE
Add animated wavy background styling

### DIFF
--- a/soru.html
+++ b/soru.html
@@ -20,8 +20,13 @@
             --warning-color: #F59E0B;
             --info-color: #06B6D4;
             --modal-bg: rgba(0, 0, 0, 0.5);
-            --card-bg: white;
+            --card-bg: rgba(255, 255, 255, 0.88);
             --border-color: #e1e5e9;
+            --gradient-1: rgba(59, 130, 246, 0.45);
+            --gradient-2: rgba(6, 182, 212, 0.4);
+            --gradient-3: rgba(244, 114, 182, 0.45);
+            --gradient-4: rgba(125, 211, 252, 0.35);
+            --wave-opacity: 0.75;
         }
 
         /* Dark Theme */
@@ -31,10 +36,15 @@
             --secondary-color: #16213e;
             --accent-color: #e94560;
             --text-color: #f5f5f5;
-            --card-bg: #16213e;
+            --card-bg: rgba(22, 33, 62, 0.85);
             --border-color: #0f3460;
+            --gradient-1: rgba(79, 70, 229, 0.55);
+            --gradient-2: rgba(6, 182, 212, 0.35);
+            --gradient-3: rgba(233, 69, 96, 0.4);
+            --gradient-4: rgba(15, 52, 96, 0.55);
+            --wave-opacity: 0.65;
         }
-        
+
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             background-color: var(--bg-color);
@@ -46,8 +56,26 @@
             margin: 0;
             overflow: hidden;
             transition: all 0.3s ease;
+            position: relative;
         }
-        
+
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            background:
+                radial-gradient(circle at 20% 20%, var(--gradient-1), transparent 55%),
+                radial-gradient(circle at 80% 20%, var(--gradient-2), transparent 55%),
+                radial-gradient(circle at 50% 80%, var(--gradient-3), transparent 55%),
+                linear-gradient(120deg, var(--gradient-4), transparent 70%);
+            background-size: 160% 160%, 150% 150%, 170% 170%, 200% 200%;
+            background-position: 0% 0%, 100% 0%, 50% 100%, 0% 50%;
+            opacity: var(--wave-opacity);
+            animation: aiWave 28s ease-in-out infinite;
+            z-index: -1;
+            pointer-events: none;
+        }
+
         .container {
             width: 95%;
             max-width: 1200px;
@@ -60,6 +88,8 @@
             padding: 20px;
             box-sizing: border-box;
             position: relative;
+            backdrop-filter: blur(14px);
+            -webkit-backdrop-filter: blur(14px);
         }
 
         /* Theme Toggle Button */
@@ -332,6 +362,18 @@
         @keyframes pulse {
             0%, 100% { transform: scale(1); }
             50% { transform: scale(1.05); }
+        }
+
+        @keyframes aiWave {
+            0% {
+                background-position: 0% 0%, 100% 0%, 50% 100%, 0% 50%;
+            }
+            50% {
+                background-position: 50% 40%, 50% 50%, 60% 80%, 100% 60%;
+            }
+            100% {
+                background-position: 0% 0%, 100% 0%, 50% 100%, 0% 50%;
+            }
         }
 
         /* Jokers */


### PR DESCRIPTION
## Summary
- introduce theme-aware gradient tokens and an animated wavy background overlay for an AI-inspired vibe
- soften quiz surfaces with translucent cards and backdrop blur while keeping question text legible
- preserve the existing game flow and layout while updating the visual atmosphere

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce66651b88832cb6404eaa310ca9c7